### PR TITLE
Also remove quality-abr state class on quality classes refresh (#6)

### DIFF
--- a/flowplayer.quality-selector.js
+++ b/flowplayer.quality-selector.js
@@ -108,6 +108,7 @@
 
     function removeAllQualityClasses() {
       if (!api.qualities || !api.qualities.length) return;
+      common.removeClass(root, 'quality-abr');
       api.qualities.forEach(function(quality) {
         common.removeClass(root, 'quality-' + quality);
       });


### PR DESCRIPTION
It makes sense though not to list "abr" in api.qualities because they
designate manually selectable single qualities.
