### PR TITLE
Don't require flowplayer directly

### DIFF
--- a/flowplayer.quality-selector.js
+++ b/flowplayer.quality-selector.js
@@ -11,7 +11,7 @@
 
 */
 
-(function(flowplayer) {
+var extension = function(flowplayer) {
   flowplayer(function(api, root) {
     'use strict';
     var common = flowplayer.common
@@ -166,4 +166,7 @@
     }
 
   });
-})(typeof module === 'object' && module.exports ? require('flowplayer') : window.flowplayer);
+};
+
+if (typeof module === 'object' && module.exports) module.exports = extension;
+else if (window.flowplayer) extension(window.flowplayer);


### PR DESCRIPTION
If required directly prevents usage with the commercial player.

@blacktrash please check if you find any problems with this in our common use cases.
