### PR TITLE
Downsize selector widget (#14)

### DIFF
--- a/stylus/flowplayer.quality-selector.styl
+++ b/stylus/flowplayer.quality-selector.styl
@@ -18,7 +18,6 @@
     bottom 40px
     width 0px
     overflow hidden
-    font-size 12px
     font-weight bold
 
     li
@@ -26,9 +25,10 @@
       list-style none
       background-color #333
       background-color rgba(#333, 0.6)
-      margin 5px
-      padding 5px
-      border-radius 3px
+      margin 2px
+      padding 4px
+      border-radius 2px
+      font-size 80%
       color #fff
       text-shadow 0px 0px 2px #000
       overflow hidden
@@ -46,7 +46,11 @@
         background-color rgba(#333, 0.8)
   &.is-mouseover
     .fp-quality-selector
-      width 80px
+      width 5em
   &.is-finished, &.is-disabled
     .fp-quality-selector
       width 0px
+
+.flowplayer.fixed-controls
+  .fp-quality-selector
+    bottom 10px


### PR DESCRIPTION
Reduce the risk of the selector overlaying other vital controls,
especially on mobiles.
- make font-size rule actually work by assigning it to the ul's li
  element
- use percentage for font-size, and only 80%
- reduce margins, padding, and border-radius
- use em unit for width
- move widget to bottom with fixed-controls
